### PR TITLE
size same for price boxes

### DIFF
--- a/workshop/static/workshop/css/workshop-2023.css
+++ b/workshop/static/workshop/css/workshop-2023.css
@@ -238,7 +238,16 @@ html, body {
   border-radius: 10px;
   box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
   background-color: white;
+  min-height: 542px;
   /* margin: 0 35px; */
+}
+
+.payment-purchase {
+  position: absolute;
+  bottom: 30px;
+  display: flex;
+  width: 100%;
+  width: calc(100% - 30px);
 }
 
 .venue-content {
@@ -278,6 +287,10 @@ html, body {
     padding-left: 10px;
     padding-right: 10px;
     padding-bottom: 0;
+  }
+
+  .payment-purchase {
+    width: 100%;
   }
 
 


### PR DESCRIPTION
This PR makes the box sizes of the registration details uniform.

<img width="885" alt="Screenshot 2024-10-08 at 12 02 12 PM" src="https://github.com/user-attachments/assets/dbd131ca-a56b-48f4-b149-31bed6767350">
